### PR TITLE
Extension of Message Manager to handle channel subscription and message selection

### DIFF
--- a/config/module.cfg
+++ b/config/module.cfg
@@ -76,4 +76,10 @@ TacticsAmbulanceCentre.CommandPicker : adf.sample.centralized.CommandPickerAmbul
 TacticsFireStation.CommandPicker : adf.sample.centralized.CommandPickerFire
 TacticsPoliceOffice.CommandPicker : adf.sample.centralized.CommandPickerPolice
 
+MessageManager.PlatoonChannelSubscriber : adf.sample.module.comm.SampleChannelSubscriber
+MessageManager.CenterChannelSubscriber : adf.sample.module.comm.SampleChannelSubscriber
+
+MessageManager.PlatoonMessageCoordinator : adf.sample.module.comm.SampleMessageCoordinator
+MessageManager.CenterMessageCoordinator : adf.sample.module.comm.SampleMessageCoordinator
+
 VisualDebug:true

--- a/src/adf/sample/module/comm/SampleChannelSubscriber.java
+++ b/src/adf/sample/module/comm/SampleChannelSubscriber.java
@@ -27,22 +27,8 @@ public class SampleChannelSubscriber extends ChannelSubscriber {
 
             StandardEntityURN agentType = getAgentType(agentInfo, worldInfo);
             int[] channels = new int[maxChannelCount];
-            int agentInc = 0;
-            if (agentType == StandardEntityURN.FIRE_BRIGADE || agentType == StandardEntityURN.FIRE_STATION) {
-                agentInc = 1;
-            } else if (agentType == StandardEntityURN.POLICE_FORCE || agentType == StandardEntityURN.POLICE_OFFICE) {
-                agentInc = 2;
-            } else if (agentType == StandardEntityURN.AMBULANCE_TEAM || agentType == StandardEntityURN.AMBULANCE_CENTRE) {
-                agentInc = 3;
-            }
-
             for (int i = 0; i < maxChannelCount; i++) {
-                int ch = (i*3)+agentInc;
-                if (ch > numChannels) {
-                    ch = (ch % numChannels)+1;
-                }
-                channels[i] = ch;
-                System.out.println("[" + agentInfo.getID() + "] Subscribe to channel:" + ch + " numChannels:" + numChannels + " maxChannelCount:" + maxChannelCount);
+                channels[i] = getChannelNumber(agentType, i, numChannels);
             }
 
             messageManager.subscribeToChannels(channels);
@@ -62,5 +48,38 @@ public class SampleChannelSubscriber extends ChannelSubscriber {
     protected StandardEntityURN getAgentType(AgentInfo agentInfo, WorldInfo worldInfo) {
         StandardEntityURN agentType = worldInfo.getEntity(agentInfo.getID()).getStandardURN();
         return agentType;
+    }
+
+    public static int getChannelNumber(StandardEntityURN agentType, int channelIndex, int numChannels) {
+        int agentIndex = 0;
+        if (agentType == StandardEntityURN.FIRE_BRIGADE || agentType == StandardEntityURN.FIRE_STATION) {
+            agentIndex = 1;
+        } else if (agentType == StandardEntityURN.POLICE_FORCE || agentType == StandardEntityURN.POLICE_OFFICE) {
+            agentIndex = 2;
+        } else if (agentType == StandardEntityURN.AMBULANCE_TEAM || agentType == StandardEntityURN.AMBULANCE_CENTRE) {
+            agentIndex = 3;
+        }
+
+        int index = (3*channelIndex)+agentIndex;
+        if ((index%numChannels) == 0) {
+            index = numChannels;
+        } else {
+            index = index % numChannels;
+        }
+        return index;
+    }
+
+    public static void main(String[] args) {
+        int numChannels = 6;
+        int maxChannels = 2;
+        for (int i = 0; i < maxChannels; i++) {
+            System.out.println("FIREBRIGADE-" + i + ":" + getChannelNumber(StandardEntityURN.FIRE_BRIGADE, i, numChannels));
+        }
+        for (int i = 0; i < maxChannels; i++) {
+            System.out.println("POLICE-" + i + ":" + getChannelNumber(StandardEntityURN.POLICE_OFFICE, i, numChannels));
+        }
+        for (int i = 0; i < maxChannels; i++) {
+            System.out.println("AMB-" + i + ":" + getChannelNumber(StandardEntityURN.AMBULANCE_CENTRE, i, numChannels));
+        }
     }
 }

--- a/src/adf/sample/module/comm/SampleChannelSubscriber.java
+++ b/src/adf/sample/module/comm/SampleChannelSubscriber.java
@@ -1,0 +1,66 @@
+package adf.sample.module.comm;
+
+import adf.agent.communication.MessageManager;
+import adf.agent.info.AgentInfo;
+import adf.agent.info.ScenarioInfo;
+import adf.agent.info.WorldInfo;
+import adf.component.communication.ChannelSubscriber;
+import rescuecore2.standard.entities.StandardEntityURN;
+
+public class SampleChannelSubscriber extends ChannelSubscriber {
+
+
+    @Override
+    public void subscribe(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo,
+                          MessageManager messageManager) {
+        // subscribe only once at the beginning
+        if (agentInfo.getTime() == 1) {
+            int numChannels = scenarioInfo.getCommsChannelsCount()-1; // 0th channel is the voice channel
+
+            int maxChannelCount = 0;
+            boolean isPlatoon = isPlatoonAgent(agentInfo, worldInfo);
+            if (isPlatoon) {
+                maxChannelCount = scenarioInfo.getCommsChannelsMaxPlatoon();
+            } else {
+                maxChannelCount = scenarioInfo.getCommsChannelsMaxOffice();
+            }
+
+            StandardEntityURN agentType = getAgentType(agentInfo, worldInfo);
+            int[] channels = new int[maxChannelCount];
+            int agentInc = 0;
+            if (agentType == StandardEntityURN.FIRE_BRIGADE || agentType == StandardEntityURN.FIRE_STATION) {
+                agentInc = 1;
+            } else if (agentType == StandardEntityURN.POLICE_FORCE || agentType == StandardEntityURN.POLICE_OFFICE) {
+                agentInc = 2;
+            } else if (agentType == StandardEntityURN.AMBULANCE_TEAM || agentType == StandardEntityURN.AMBULANCE_CENTRE) {
+                agentInc = 3;
+            }
+
+            for (int i = 0; i < maxChannelCount; i++) {
+                int ch = (i*3)+agentInc;
+                if (ch > numChannels) {
+                    ch = (ch % numChannels)+1;
+                }
+                channels[i] = ch;
+                System.out.println("[" + agentInfo.getID() + "] Subscribe to channel:" + ch + " numChannels:" + numChannels + " maxChannelCount:" + maxChannelCount);
+            }
+
+            messageManager.subscribeToChannels(channels);
+        }
+    }
+
+    protected boolean isPlatoonAgent(AgentInfo agentInfo, WorldInfo worldInfo) {
+        StandardEntityURN agentType = getAgentType(agentInfo, worldInfo);
+        if (agentType == StandardEntityURN.FIRE_BRIGADE ||
+                agentType == StandardEntityURN.POLICE_FORCE ||
+                agentType == StandardEntityURN.AMBULANCE_TEAM) {
+            return true;
+        }
+        return false;
+    }
+
+    protected StandardEntityURN getAgentType(AgentInfo agentInfo, WorldInfo worldInfo) {
+        StandardEntityURN agentType = worldInfo.getEntity(agentInfo.getID()).getStandardURN();
+        return agentType;
+    }
+}

--- a/src/adf/sample/module/comm/SampleMessageCoordinator.java
+++ b/src/adf/sample/module/comm/SampleMessageCoordinator.java
@@ -1,0 +1,203 @@
+package adf.sample.module.comm;
+
+import adf.agent.communication.MessageManager;
+import adf.agent.communication.standard.bundle.StandardMessage;
+import adf.agent.communication.standard.bundle.StandardMessagePriority;
+import adf.agent.communication.standard.bundle.centralized.MessageReport;
+import adf.agent.communication.standard.bundle.centralized.CommandAmbulance;
+import adf.agent.communication.standard.bundle.centralized.CommandFire;
+import adf.agent.communication.standard.bundle.centralized.CommandPolice;
+import adf.agent.communication.standard.bundle.centralized.CommandScout;
+import adf.agent.communication.standard.bundle.information.MessageAmbulanceTeam;
+import adf.agent.communication.standard.bundle.information.MessageBuilding;
+import adf.agent.communication.standard.bundle.information.MessageCivilian;
+import adf.agent.communication.standard.bundle.information.MessageFireBrigade;
+import adf.agent.communication.standard.bundle.information.MessagePoliceForce;
+import adf.agent.communication.standard.bundle.information.MessageRoad;
+import adf.agent.info.AgentInfo;
+import adf.agent.info.ScenarioInfo;
+import adf.agent.info.WorldInfo;
+import adf.component.communication.CommunicationMessage;
+import adf.component.communication.MessageCoordinator;
+import rescuecore2.standard.entities.StandardEntityURN;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SampleMessageCoordinator extends MessageCoordinator {
+
+    @Override
+    public void coordinate(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, MessageManager messageManager,
+                           ArrayList<CommunicationMessage> sendMessageList, List<List<CommunicationMessage>> channelSendMessageList) {
+
+        // have different lists for every agent
+        ArrayList<CommunicationMessage> policeMessages = new ArrayList<>();
+        ArrayList<CommunicationMessage> ambulanceMessages = new ArrayList<>();
+        ArrayList<CommunicationMessage> fireBrigadeMessages = new ArrayList<>();
+
+        ArrayList<CommunicationMessage> voiceMessages = new ArrayList<>();
+
+        StandardEntityURN agentType = getAgentType(agentInfo, worldInfo);
+
+        for (CommunicationMessage msg : sendMessageList) {
+            if (msg instanceof StandardMessage && !((StandardMessage)msg).isRadio()) {
+                voiceMessages.add(msg);
+            } else {
+                if (msg instanceof MessageBuilding) {
+                    fireBrigadeMessages.add(msg);
+                } else if (msg instanceof MessageCivilian) {
+                    ambulanceMessages.add(msg);
+                } else if (msg instanceof MessageRoad) {
+                    fireBrigadeMessages.add(msg);
+                    ambulanceMessages.add(msg);
+                    policeMessages.add(msg);
+                } else if (msg instanceof CommandAmbulance) {
+                    ambulanceMessages.add(msg);
+                } else if (msg instanceof CommandFire) {
+                    fireBrigadeMessages.add(msg);
+                } else if (msg instanceof CommandPolice) {
+                    policeMessages.add(msg);
+                } else if (msg instanceof CommandScout) {
+                    if (agentType == StandardEntityURN.FIRE_STATION) {
+                        fireBrigadeMessages.add(msg);
+                    } else if (agentType == StandardEntityURN.POLICE_OFFICE) {
+                        policeMessages.add(msg);
+                    } else if (agentType == StandardEntityURN.AMBULANCE_CENTRE) {
+                        ambulanceMessages.add(msg);
+                    }
+                } else if (msg instanceof MessageReport) {
+                    if (agentType == StandardEntityURN.FIRE_BRIGADE) {
+                        fireBrigadeMessages.add(msg);
+                    } else if (agentType == StandardEntityURN.POLICE_FORCE) {
+                        policeMessages.add(msg);
+                    } else if (agentType == StandardEntityURN.AMBULANCE_TEAM) {
+                        ambulanceMessages.add(msg);
+                    }
+                } else if (msg instanceof MessageFireBrigade) {
+                    fireBrigadeMessages.add(msg);
+                    ambulanceMessages.add(msg);
+                    policeMessages.add(msg);
+                } else if (msg instanceof MessagePoliceForce) {
+                    ambulanceMessages.add(msg);
+                    policeMessages.add(msg);
+                } else if (msg instanceof MessageAmbulanceTeam) {
+                    ambulanceMessages.add(msg);
+                    policeMessages.add(msg);
+                }
+            }
+        }
+
+        int[] channelSize = new int[scenarioInfo.getCommsChannelsCount()-1];
+
+        setSendMessages(scenarioInfo, StandardEntityURN.POLICE_FORCE, agentInfo, worldInfo, policeMessages,
+                channelSendMessageList, channelSize);
+        setSendMessages(scenarioInfo, StandardEntityURN.AMBULANCE_TEAM, agentInfo, worldInfo, ambulanceMessages,
+                channelSendMessageList, channelSize);
+        setSendMessages(scenarioInfo, StandardEntityURN.FIRE_BRIGADE, agentInfo, worldInfo, fireBrigadeMessages,
+                channelSendMessageList, channelSize);
+
+        ArrayList<StandardMessage> voiceMessageLowList = new ArrayList<>();
+        ArrayList<StandardMessage> voiceMessageNormalList = new ArrayList<>();
+        ArrayList<StandardMessage> voiceMessageHighList = new ArrayList<>();
+
+        for (CommunicationMessage msg : voiceMessages) {
+            if (msg instanceof StandardMessage) {
+                StandardMessage m = (StandardMessage) msg;
+                switch (m.getSendingPriority()) {
+                    case LOW:
+                        voiceMessageLowList.add(m);
+                        break;
+                    case NORMAL:
+                        voiceMessageNormalList.add(m);
+                        break;
+                    case HIGH:
+                        voiceMessageHighList.add(m);
+                        break;
+                }
+            }
+        }
+
+        // set the voice channel messages
+        channelSendMessageList.get(0).addAll(voiceMessageHighList);
+        channelSendMessageList.get(0).addAll(voiceMessageNormalList);
+        channelSendMessageList.get(0).addAll(voiceMessageLowList);
+    }
+
+    protected int[] getChannelsByAgentType(StandardEntityURN agentType, AgentInfo agentInfo,
+                                        WorldInfo worldInfo, ScenarioInfo scenarioInfo, int channelIndex) {
+        int agentIndex = 0;
+        if (agentType == StandardEntityURN.FIRE_BRIGADE || agentType == StandardEntityURN.FIRE_STATION) {
+            agentIndex = 1;
+        } else if (agentType == StandardEntityURN.POLICE_FORCE || agentType == StandardEntityURN.POLICE_OFFICE) {
+            agentIndex = 2;
+        } else if (agentType == StandardEntityURN.AMBULANCE_TEAM || agentType == StandardEntityURN.AMBULANCE_CENTRE) {
+            agentIndex = 3;
+        }
+        int numChannels = scenarioInfo.getCommsChannelsCount()-1; // 0th channel is the voice channel
+
+        int maxChannelCount = 0;
+        boolean isPlatoon = isPlatoonAgent(agentInfo, worldInfo);
+        if (isPlatoon) {
+            maxChannelCount = scenarioInfo.getCommsChannelsMaxPlatoon();
+        } else {
+            maxChannelCount = scenarioInfo.getCommsChannelsMaxOffice();
+        }
+        int[] channels = new int[maxChannelCount];
+
+        for (int i = 0; i < maxChannelCount; i++) {
+            int ch = (i*3)+agentIndex;
+            if (ch > numChannels) {
+                ch = (ch % numChannels)+1;
+            }
+            channels[i] = ch;
+        }
+        return channels;
+    }
+
+    protected boolean isPlatoonAgent(AgentInfo agentInfo, WorldInfo worldInfo) {
+        StandardEntityURN agentType = getAgentType(agentInfo, worldInfo);
+        if (agentType == StandardEntityURN.FIRE_BRIGADE ||
+                agentType == StandardEntityURN.POLICE_FORCE ||
+                agentType == StandardEntityURN.AMBULANCE_TEAM) {
+            return true;
+        }
+        return false;
+    }
+
+    protected StandardEntityURN getAgentType(AgentInfo agentInfo, WorldInfo worldInfo) {
+        StandardEntityURN agentType = worldInfo.getEntity(agentInfo.getID()).getStandardURN();
+        return agentType;
+    }
+
+    protected void setSendMessages(ScenarioInfo scenarioInfo, StandardEntityURN agentType, AgentInfo agentInfo,
+                                   WorldInfo worldInfo, List<CommunicationMessage> messages,
+                                   List<List<CommunicationMessage>> channelSendMessageList,
+                                   int[] channelSize) {
+        int channelIndex = 0;
+        int[] channels = getChannelsByAgentType(agentType, agentInfo, worldInfo, scenarioInfo, channelIndex);
+        int channel = channels[channelIndex];
+        int channelCapacity = scenarioInfo.getCommsChannelBandwidth(channel);
+        // start from HIGH, NORMAL, to LOW
+        for (int i = StandardMessagePriority.values().length-1; i >= 0; i--) {
+            for (CommunicationMessage msg : messages) {
+                StandardMessage smsg = (StandardMessage) msg;
+                if (smsg.getSendingPriority() == StandardMessagePriority.values()[i]) {
+                    channelSize[channel-1] += smsg.getByteArraySize();
+                    if (channelSize[channel-1] > channelCapacity) {
+                        channelSize[channel-1] -= smsg.getByteArraySize();
+                        channelIndex++;
+                        if (channelIndex < channels.length) {
+                            channel = channels[channelIndex];
+                            channelCapacity = scenarioInfo.getCommsChannelBandwidth(channel);
+                            channelSize[channel-1] += smsg.getByteArraySize();
+                        } else {
+                            // if there is no new channel for that message types, just break
+                            break;
+                        }
+                    }
+                    channelSendMessageList.get(channel).add(smsg);
+                }
+            }
+        }
+    }
+}

--- a/src/adf/sample/module/comm/SampleMessageCoordinator.java
+++ b/src/adf/sample/module/comm/SampleMessageCoordinator.java
@@ -125,16 +125,7 @@ public class SampleMessageCoordinator extends MessageCoordinator {
 
     protected int[] getChannelsByAgentType(StandardEntityURN agentType, AgentInfo agentInfo,
                                         WorldInfo worldInfo, ScenarioInfo scenarioInfo, int channelIndex) {
-        int agentIndex = 0;
-        if (agentType == StandardEntityURN.FIRE_BRIGADE || agentType == StandardEntityURN.FIRE_STATION) {
-            agentIndex = 1;
-        } else if (agentType == StandardEntityURN.POLICE_FORCE || agentType == StandardEntityURN.POLICE_OFFICE) {
-            agentIndex = 2;
-        } else if (agentType == StandardEntityURN.AMBULANCE_TEAM || agentType == StandardEntityURN.AMBULANCE_CENTRE) {
-            agentIndex = 3;
-        }
         int numChannels = scenarioInfo.getCommsChannelsCount()-1; // 0th channel is the voice channel
-
         int maxChannelCount = 0;
         boolean isPlatoon = isPlatoonAgent(agentInfo, worldInfo);
         if (isPlatoon) {
@@ -145,11 +136,7 @@ public class SampleMessageCoordinator extends MessageCoordinator {
         int[] channels = new int[maxChannelCount];
 
         for (int i = 0; i < maxChannelCount; i++) {
-            int ch = (i*3)+agentIndex;
-            if (ch > numChannels) {
-                ch = (ch % numChannels)+1;
-            }
-            channels[i] = ch;
+            channels[i] = SampleChannelSubscriber.getChannelNumber(agentType, i, numChannels);
         }
         return channels;
     }

--- a/src/adf/sample/tactics/SampleTacticsAmbulanceCentre.java
+++ b/src/adf/sample/tactics/SampleTacticsAmbulanceCentre.java
@@ -7,7 +7,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandPicker;
 import adf.component.communication.CommunicationMessage;
 import adf.component.module.complex.TargetAllocator;
@@ -25,6 +25,9 @@ public class SampleTacticsAmbulanceCentre extends TacticsAmbulanceCentre
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData debugData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.CenterChannelSubscriber", "adf.sample.module.comm.SampleChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.CenterMessageCoordinator", "adf.sample.module.comm.SampleMessageCoordinator"));
+
         switch (scenarioInfo.getMode())
         {
             case PRECOMPUTATION_PHASE:

--- a/src/adf/sample/tactics/SampleTacticsAmbulanceTeam.java
+++ b/src/adf/sample/tactics/SampleTacticsAmbulanceTeam.java
@@ -16,7 +16,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandExecutor;
 import adf.component.communication.CommunicationMessage;
 import adf.component.extaction.ExtAction;
@@ -50,6 +50,9 @@ public class SampleTacticsAmbulanceTeam extends TacticsAmbulanceTeam
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData developData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.PlatoonChannelSubscriber", "adf.sample.module.comm.SampleChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.PlatoonMessageCoordinator", "adf.sample.module.comm.SampleMessageCoordinator"));
+
         worldInfo.indexClass(
                 StandardEntityURN.CIVILIAN,
                 StandardEntityURN.FIRE_BRIGADE,

--- a/src/adf/sample/tactics/SampleTacticsFireBrigade.java
+++ b/src/adf/sample/tactics/SampleTacticsFireBrigade.java
@@ -11,7 +11,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandExecutor;
 import adf.component.communication.CommunicationMessage;
 import adf.component.extaction.ExtAction;
@@ -51,6 +51,9 @@ public class SampleTacticsFireBrigade extends TacticsFireBrigade
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData developData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.PlatoonChannelSubscriber", "adf.sample.module.comm.SampleChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.PlatoonMessageCoordinator", "adf.sample.module.comm.SampleMessageCoordinator"));
+
         worldInfo.indexClass(
                 StandardEntityURN.ROAD,
                 StandardEntityURN.HYDRANT,

--- a/src/adf/sample/tactics/SampleTacticsFireStation.java
+++ b/src/adf/sample/tactics/SampleTacticsFireStation.java
@@ -7,7 +7,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandPicker;
 import adf.component.communication.CommunicationMessage;
 import adf.component.module.complex.TargetAllocator;
@@ -25,6 +25,9 @@ public class SampleTacticsFireStation extends TacticsFireStation
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData debugData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.CenterChannelSubscriber", "adf.sample.module.comm.SampleChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.CenterMessageCoordinator", "adf.sample.module.comm.SampleMessageCoordinator"));
+
         switch (scenarioInfo.getMode())
         {
             case PRECOMPUTATION_PHASE:

--- a/src/adf/sample/tactics/SampleTacticsPoliceForce.java
+++ b/src/adf/sample/tactics/SampleTacticsPoliceForce.java
@@ -14,7 +14,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandExecutor;
 import adf.component.communication.CommunicationMessage;
 import adf.component.extaction.ExtAction;
@@ -53,6 +53,9 @@ public class SampleTacticsPoliceForce extends TacticsPoliceForce
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData developData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.PlatoonChannelSubscriber", "adf.sample.module.comm.SampleChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.PlatoonMessageCoordinator", "adf.sample.module.comm.SampleMessageCoordinator"));
+
         worldInfo.indexClass(
                 StandardEntityURN.ROAD,
                 StandardEntityURN.HYDRANT,

--- a/src/adf/sample/tactics/SampleTacticsPoliceOffice.java
+++ b/src/adf/sample/tactics/SampleTacticsPoliceOffice.java
@@ -7,7 +7,7 @@ import adf.agent.info.ScenarioInfo;
 import adf.agent.info.WorldInfo;
 import adf.agent.module.ModuleManager;
 import adf.agent.precompute.PrecomputeData;
-import adf.agent.utils.WorldViewLauncher;
+import adf.debug.WorldViewLauncher;
 import adf.component.centralized.CommandPicker;
 import adf.component.communication.CommunicationMessage;
 import adf.component.module.complex.TargetAllocator;
@@ -25,6 +25,9 @@ public class SampleTacticsPoliceOffice extends TacticsPoliceOffice
     @Override
     public void initialize(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, ModuleManager moduleManager, MessageManager messageManager, DevelopData debugData)
     {
+        messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.CenterChannelSubscriber", "adf.component.communication.ChannelSubscriber"));
+        messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.CenterMessageCoordinator", "adf.agent.communication.standard.bundle.StandardMessageCoordinator"));
+
         switch  (scenarioInfo.getMode())
         {
             case PRECOMPUTATION_PHASE:


### PR DESCRIPTION
The Extension of Message Manager handles the channel subscription and the message selection. The current message manager only subscribes to the channel 1 and the current message selection favors command messages over information messages.

With this change the teams will be able to develop their own channel subscription and message selection strategy. We have sample subscription and selection module. Sample channel subscription module subscribes different channels for every agent types if possible. If there are only 2 channels, one agent type uses one channel and other two agent types use the other channel. Sample message coordinator reimplements the message priority based on the predefined priority of the the message. We also push the messages according to the type of the message. For example, CommandPolice message is sent only to the Police agent channel.