### PR TITLE
:gear: Configure Java 21 toolchain with auto-download support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ group = 'com.github.roborescue'
 
 version = '4.1'
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(21)
+  }
+}
+
 dependencies {
   implementation fileTree(dir: 'lib', include: '*.jar')
   implementation 'com.github.roborescue:rcrs-server:master-SNAPSHOT'
@@ -28,7 +34,7 @@ repositories {
     url = 'https://repo.enonic.com/public/'
   }
   maven {
-    url 'https://jitpack.io'
+    url = 'https://jitpack.io'
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'adf-sample-agent-java'


### PR DESCRIPTION
@gnardin 

I confirmed that the build works successfully with the following changes.

https://github.com/roborescue/rcrs-server/pull/89
>I merger the pull request because it seems the only way to effectively test it. Can you please provide a feedback if it really worked?

I also noticed that the JDK version has been updated to 21. This seems like a reasonable decision considering the end of support for older versions. However, it may increase the setup cost for users.

Therefore, I would like to propose using Gradle's toolchain auto-download feature so that the required JDK can be automatically installed.

Please consider this change.